### PR TITLE
Support running the current test group

### DIFF
--- a/lisp/pytest-info.el
+++ b/lisp/pytest-info.el
@@ -37,19 +37,19 @@
 
 (defun pytest-info--as-group (selector)
   "Get the test group of SELECTOR or nil."
-  (let ((file-path (car selector)) (components (cdr selector)) group-selector)
-    (message "raw selector: %s" selector)
-    (message "components: %s" components)
-    selector))
+  (let ((file-path (car selector)) (components (cdr selector)) group-components group-selector)
+    (setq group-components (loop for elem in components while (s-starts-with-p "Test" elem) collect elem))
+    (setq group-selector (if (> (length group-components) 0)
+                             (cons file-path group-components)
+                           nil))
+    group-selector))
 
 (defun pytest-info-current-group ()
   "Get a selector for the current test group."
   (interactive)
   (let (selector group-selector)
     (setq selector (pytest-info--current-selector))
-    (message "selector: %s" selector)
     (setq group-selector (pytest-info--as-group selector))
-    (message "current group: %s" group-selector)
     group-selector))
 
 (provide 'pytest-info)

--- a/lisp/pytest-info.el
+++ b/lisp/pytest-info.el
@@ -30,5 +30,10 @@
     (setq selector (pytest-info--as-selector info))
     selector))
 
+(defun pytest-info-current-test ()
+  "Get a selector for the current test."
+  (interactive)
+  (let (selector (pytest-info--current-selector))
+    selector))
 (provide 'pytest-info)
 ;;; pytest-info.el ends here

--- a/lisp/pytest-info.el
+++ b/lisp/pytest-info.el
@@ -32,8 +32,25 @@
 
 (defun pytest-info-current-test ()
   "Get a selector for the current test."
-  (interactive)
-  (let (selector (pytest-info--current-selector))
+  (let ((selector (pytest-info--current-selector)))
     selector))
+
+(defun pytest-info--as-group (selector)
+  "Get the test group of SELECTOR or nil."
+  (let ((file-path (car selector)) (components (cdr selector)) group-selector)
+    (message "raw selector: %s" selector)
+    (message "components: %s" components)
+    selector))
+
+(defun pytest-info-current-group ()
+  "Get a selector for the current test group."
+  (interactive)
+  (let (selector group-selector)
+    (setq selector (pytest-info--current-selector))
+    (message "selector: %s" selector)
+    (setq group-selector (pytest-info--as-group selector))
+    (message "current group: %s" group-selector)
+    group-selector))
+
 (provide 'pytest-info)
 ;;; pytest-info.el ends here

--- a/lisp/pytest-info.el
+++ b/lisp/pytest-info.el
@@ -46,7 +46,6 @@
 
 (defun pytest-info-current-group ()
   "Get a selector for the current test group."
-  (interactive)
   (let (selector group-selector)
     (setq selector (pytest-info--current-selector))
     (setq group-selector (pytest-info--as-group selector))

--- a/lisp/pytest-info.el
+++ b/lisp/pytest-info.el
@@ -24,8 +24,8 @@
         (name (nth 1 info)))
     (cons file-path (s-split "\\." name))))
 
-(defun pytest-info-current-pos ()
-  "Get a selector for the current test."
+(defun pytest-info--current-selector ()
+  "Get a selector for the current position."
   (let ((info (pytest-info--current-pos)) selector)
     (setq selector (pytest-info--as-selector info))
     selector))

--- a/lisp/pytest-raw.el
+++ b/lisp/pytest-raw.el
@@ -128,6 +128,12 @@ If DIR is non-nil, run pytest in it."
   (let ((selector (pytest-info-current-test)))
     (pytest-run-selector selector)))
 
+(defun pytest-run-current-group ()
+  "Run the test group at point."
+  (interactive)
+  (let ((selector (pytest-info-current-group)))
+    (pytest-run-selector selector)))
+
 (defun pytest-raw-rerun ()
   "Rerun the selectors in a raw buffer."
   (interactive)

--- a/lisp/pytest-raw.el
+++ b/lisp/pytest-raw.el
@@ -125,7 +125,7 @@ If DIR is non-nil, run pytest in it."
 (defun pytest-run-current-test ()
   "Run the test at point."
   (interactive)
-  (let ((selector (pytest-info-current-pos)))
+  (let ((selector (pytest-info-current-test)))
     (pytest-run-selector selector)))
 
 (defun pytest-raw-rerun ()

--- a/lisp/pytest.el
+++ b/lisp/pytest.el
@@ -34,6 +34,7 @@
   "Set up pytest keybindings in `python-mode'."
   (define-key python-mode-map (kbd "<f5>") 'pytest-run-current-file)
   (define-key python-mode-map (kbd "<S-f5>") 'pytest-run-current-test)
+  (define-key python-mode-map (kbd "<M-S-f5") 'pytest-run-current-group)
   (define-key python-mode-map (kbd "<C-f5>") 'pytest-run-all))
 (add-hook 'python-mode-hook 'setup-pytest-keybindings)
 

--- a/lisp/pytest.el
+++ b/lisp/pytest.el
@@ -34,8 +34,8 @@
   "Set up pytest keybindings in `python-mode'."
   (define-key python-mode-map (kbd "<f5>") 'pytest-run-current-file)
   (define-key python-mode-map (kbd "<S-f5>") 'pytest-run-current-test)
-  (define-key python-mode-map (kbd "<M-S-f5") 'pytest-run-current-group)
-  (define-key python-mode-map (kbd "<C-f5>") 'pytest-run-all))
+  (define-key python-mode-map (kbd "<C-f5") 'pytest-run-current-group)
+  (define-key python-mode-map (kbd "<M-f5>") 'pytest-run-all))
 (add-hook 'python-mode-hook 'setup-pytest-keybindings)
 
 (require 'projectile)


### PR DESCRIPTION
"Test groups" are namespace classes with a prefix of "Test". This allows running all tests in a test group without having selected the `class ...:` line.