### PR TITLE
run all if no selectors

### DIFF
--- a/lisp/pytest-raw.el
+++ b/lisp/pytest-raw.el
@@ -141,7 +141,7 @@ If DIR is non-nil, run pytest in it."
   "Rerun the selectors in a raw buffer."
   (interactive)
   (let ((selectors (buffer-local-value 'called-selectors (current-buffer))))
-    (if selectors (pytest-run-selectors selectors))))
+    (if selectors (pytest-run-selectors selectors) (pytest-run-all))))
 
 (provide 'pytest-raw)
 ;;; pytest-raw.el ends here


### PR DESCRIPTION
which fixes the broken <kbd>r</kbd> in a buffer created by running the whole testsuite.