### PR TITLE
rewrite process

### DIFF
--- a/ci/requirements.el
+++ b/ci/requirements.el
@@ -29,7 +29,7 @@
 (package-initialize)
 
 (package-refresh-contents)
-(setq package-selected-packages '(s projectile cl buttercup))
+(setq package-selected-packages '(f s projectile cl buttercup))
 
 (package-install-selected-packages)
 

--- a/lisp/pytest-process.el
+++ b/lisp/pytest-process.el
@@ -40,12 +40,23 @@ to work in every virtual environment."
   "Construct the base command for pytest."
   (cons pytest-python-executable '("-m" "pytest")))
 
-(defun pytest--execute-async (command dir output-buffer)
-  "Execute COMMAND asynchronously in DIR and write to OUTPUT-BUFFER."
-  (let ((default-directory dir))
-    (unless (string-match "&[ \t]*\\'" command)
-      (setq command (concat command " &"))
-      (shell-command command output-buffer))))
+(defun pytest--execute (name command dir output-buffer)
+  "Execute COMMAND asynchronously in DIR.
+
+NAME is a name for the process.
+
+stdout is written to OUTPUT-BUFFER, which needs to be a buffer, not a string."
+  (let ((default-directory dir)
+        proc)
+    (with-current-buffer output-buffer
+      (ansi-color-for-comint-mode-on)
+      (comint-mode))
+    (setq proc (start-process-shell-command name
+                                            output-buffer
+                                            command))
+    (set-process-query-on-exit-flag proc nil)
+    (set-process-filter proc 'comint-output-filter)
+    proc))
 
 (defun pytest--construct-command (args)
   "Construct the pytest command using ARGS."

--- a/lisp/pytest-process.el
+++ b/lisp/pytest-process.el
@@ -74,9 +74,10 @@ If optional DIR is non-nil, pytest is run in that directory.
 Otherwise it is run in the project's root as defined by projectile or
 the current working directory.
 
-If optional OUTPUT-BUFFER is non-nil, write to the buffer with that name."
+If optional OUTPUT-BUFFER is non-nil, write to that buffer."
   (let ((command (pytest--construct-command args))
         (default-directory (or dir (projectile-project-root))))
-    (pytest--execute-async command default-directory output-buffer)))
+    (pytest--execute "pytest" command default-directory output-buffer)))
+
 (provide 'pytest-process)
 ;;; pytest-process.el ends here

--- a/lisp/pytest-process.el
+++ b/lisp/pytest-process.el
@@ -48,17 +48,8 @@ to work in every virtual environment."
 NAME is a name for the process.
 
 stdout is written to OUTPUT-BUFFER, which needs to be a buffer, not a string."
-  (let ((default-directory dir)
-        proc)
-    (with-current-buffer output-buffer
-      (ansi-color-for-comint-mode-on)
-      (comint-mode))
-    (setq proc (start-process-shell-command name
-                                            output-buffer
-                                            command))
-    (set-process-query-on-exit-flag proc nil)
-    (set-process-filter proc 'comint-output-filter)
-    proc))
+  (let ((default-directory dir))
+    (start-process-shell-command name output-buffer command)))
 
 (defun pytest--construct-command (args)
   "Construct the pytest command using ARGS."

--- a/lisp/pytest-process.el
+++ b/lisp/pytest-process.el
@@ -22,6 +22,8 @@
 ;;; Code:
 
 (require 'projectile)
+(require 's)
+
 (require 'pytest-core)
 
 (defgroup pytest-process nil

--- a/lisp/pytest-process.el
+++ b/lisp/pytest-process.el
@@ -40,7 +40,7 @@ to work in every virtual environment."
 
 (defun pytest--command ()
   "Construct the base command for pytest."
-  (cons pytest-python-executable '("-m" "pytest")))
+  (cons (executable-find pytest-python-executable) '("-m" "pytest")))
 
 (defun pytest--execute (name command dir output-buffer)
   "Execute COMMAND asynchronously in DIR.

--- a/lisp/pytest-process.el
+++ b/lisp/pytest-process.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'projectile)
+(require 'f)
 (require 's)
 
 (require 'pytest-core)
@@ -40,7 +41,9 @@ to work in every virtual environment."
 
 (defun pytest--python ()
   "Find the python executable."
-  (executable-find pytest-python-executable))
+  (if (f-absolute? pytest-python-executable)
+      pytest-python-executable
+    (executable-find pytest-python-executable)))
 
 (defun pytest--command ()
   "Construct the base command for pytest."

--- a/lisp/pytest-process.el
+++ b/lisp/pytest-process.el
@@ -38,9 +38,13 @@ to work in every virtual environment."
   :group 'pytest-process
   :type 'string)
 
+(defun pytest--python ()
+  "Find the python executable."
+  (executable-find pytest-python-executable))
+
 (defun pytest--command ()
   "Construct the base command for pytest."
-  (cons (executable-find pytest-python-executable) '("-m" "pytest")))
+  (cons (pytest--python) '("-m" "pytest")))
 
 (defun pytest--execute (name command dir output-buffer)
   "Execute COMMAND asynchronously in DIR.

--- a/lisp/pytest-raw.el
+++ b/lisp/pytest-raw.el
@@ -122,6 +122,7 @@ If DIR is non-nil, run pytest in it."
 
     (setq proc (pytest--run args dir output-buffer))
     (set-process-query-on-exit-flag proc nil)
+    (set-process-filter proc 'pytest--process-filter)))
 
 (defun pytest-run-all ()
   "Run the whole test suite."

--- a/lisp/pytest-raw.el
+++ b/lisp/pytest-raw.el
@@ -112,19 +112,16 @@ If DIR is non-nil, run pytest in it."
   (let ((selectors (pytest--normalize-selectors selectors))
         (args (append args (pytest--join-selectors selectors)))
         (output-buffer (pytest--buffer-by-name buffer-name))
-        (inhibit-read-only t)
         proc)
     (with-current-buffer output-buffer
-      (erase-buffer)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (defvar called-selectors)
+        (setq-local called-selectors selectors))
       (pytest-raw-mode))
 
     (setq proc (pytest--run args dir output-buffer))
     (set-process-query-on-exit-flag proc nil)
-    ;(set-process-filter proc 'comint-output-filter)
-
-    (with-current-buffer output-buffer
-      (defvar called-selectors)
-      (setq-local called-selectors selectors))))
 
 (defun pytest-run-all ()
   "Run the whole test suite."

--- a/lisp/pytest-raw.el
+++ b/lisp/pytest-raw.el
@@ -67,6 +67,16 @@
   :group 'pytest-modes
   :type 'hook)
 
+(defun pytest--interpret-carriage-motion (buffer min-point max-point)
+  "Interpret the carriage motion characters in a region in BUFFER.
+
+That region is between MIN-POINT and MAX-POINT."
+  (with-current-buffer buffer
+    (comint-carriage-motion min-point max-point)))
+
+(add-hook 'pytest--process-filter-preprocessors 'ansi-color-apply)
+(add-hook 'pytest--process-filter-postprocessors 'pytest--interpret-carriage-motion)
+
 (defun pytest--run-process-filter-preprocessors (output)
   "Run the registered process filters on OUTPUT."
   (let ((funs pytest--process-filter-preprocessors) (result output))
@@ -103,6 +113,7 @@
             (set-marker (process-mark proc) (point)))
           (if moving (goto-char (process-mark proc))))
       (set-buffer old-buffer))))
+
 (defun pytest--run-raw (&optional args selectors dir buffer-name)
   "Run pytest in a raw buffer named BUFFER-NAME.
 

--- a/lisp/pytest-raw.el
+++ b/lisp/pytest-raw.el
@@ -40,20 +40,21 @@
     map)
   "Keymap used in `pytest-raw-mode'.")
 
-(define-minor-mode pytest-raw-mode
-  "Minor mode for viewing raw pytest output.
+(define-derived-mode pytest-raw-mode special-mode "Pytest Raw"
+  "Major mode for viewing pytest raw output.
 
 \\{pytest-raw-mode-map}"
-  :lighter "PytestRaw"
   :group 'pytest-modes
   :keymap pytest-raw-mode-map
   (buffer-disable-undo)
+  (setq truncate-lines t)
+  (setq buffer-read-only t)
   (setq-local line-move-visual t)
   (setq-local font-lock-syntactic-face-function #'ignore)
   (setq show-trailing-whitespace nil)
-  (read-only-mode)
   (defvar quit-restore)
   (setq quit-restore "bury"))
+  ;(ansi-color-for-comint-mode-on))
 
 (defun pytest--run-raw (&optional args selectors dir buffer-name)
   "Run pytest in a raw buffer named BUFFER-NAME.
@@ -64,16 +65,15 @@ If DIR is non-nil, run pytest in it."
   (let ((selectors (pytest--normalize-selectors selectors))
         (args (append args (pytest--join-selectors selectors)))
         (output-buffer (pytest--buffer-by-name buffer-name))
+        (inhibit-read-only t)
         proc)
     (with-current-buffer output-buffer
       (erase-buffer)
-      (ansi-color-for-comint-mode-on)
-      (comint-mode)
       (pytest-raw-mode))
 
     (setq proc (pytest--run args dir output-buffer))
     (set-process-query-on-exit-flag proc nil)
-    (set-process-filter proc 'comint-output-filter)
+    ;(set-process-filter proc 'comint-output-filter)
 
     (with-current-buffer output-buffer
       (defvar called-selectors)

--- a/tests/test-info.el
+++ b/tests/test-info.el
@@ -75,19 +75,19 @@
 
   (describe "a function to check if the current statement is a decorator (pytest-info--decorator-p)"
     (it "detects the first line of a decorator"
-      (expect (with-mark-at-line buffer1 11 (pytest-info--decorator-p)) :to-be t))
+      (expect (with-mark-at-line buffer1 12 (pytest-info--decorator-p)) :to-be t))
 
     (it "detects continuation lines of a decorator"
       (expect (with-mark-at-line buffer1 44 (pytest-info--decorator-p)) :to-be t))
 
     (it "detects the indented first line of a decorator"
-      (expect (with-mark-at-line buffer2 22 (pytest-info--decorator-p)) :to-be t))
+      (expect (with-mark-at-line buffer2 24 (pytest-info--decorator-p)) :to-be t))
 
     (it "detects indented continuation lines of a decorator"
-      (expect (with-mark-at-line buffer2 17 (pytest-info--decorator-p)) :to-be t))
+      (expect (with-mark-at-line buffer2 19 (pytest-info--decorator-p)) :to-be t))
 
     (it "does not detect function declarations"
-      (expect (with-mark-at-line buffer1 12 (pytest-info--decorator-p)) :to-be nil))
+      (expect (with-mark-at-line buffer1 13 (pytest-info--decorator-p)) :to-be nil))
 
     (it "does not detect normal statements"
       (expect (with-mark-at-line buffer1 23 (pytest-info--decorator-p)) :to-be nil)))
@@ -97,24 +97,24 @@
       (expect (with-mark-at-line buffer1 5 (pytest-info-current-pos))
               :to-equal nil))
     (it "detects a plain function"
-      (expect (with-mark-at-line buffer1 7 (pytest-info-current-pos))
+      (expect (with-mark-at-line buffer1 8 (pytest-info-current-pos))
               :to-equal (list filepath1 "warn"))
       (expect (with-mark-at-line buffer1 8 (pytest-info-current-pos))
               :to-equal (list filepath1 "warn")))
     (it "detects a function with a decorator"
-      (expect (with-mark-at-line buffer1 11 (pytest-info-current-pos))
+      (expect (with-mark-at-line buffer1 12 (pytest-info-current-pos))
               :to-equal (list filepath1 "failing"))
-      (expect (with-mark-at-line buffer1 43 (pytest-info-current-pos))
+      (expect (with-mark-at-line buffer1 44 (pytest-info-current-pos))
               :to-equal (list filepath1 "test_skip")))
     (it "detects a function with multiple decorators"
-      (expect (with-mark-at-line buffer1 61 (pytest-info-current-pos))
+      (expect (with-mark-at-line buffer1 62 (pytest-info-current-pos))
               :to-equal (list filepath1 "variable"))
-      (expect (with-mark-at-line buffer1 58 (pytest-info-current-pos))
+      (expect (with-mark-at-line buffer1 59 (pytest-info-current-pos))
               :to-equal (list filepath1 "variable"))
-      (expect (with-mark-at-line buffer1 51 (pytest-info-current-pos))
+      (expect (with-mark-at-line buffer1 52 (pytest-info-current-pos))
               :to-equal (list filepath1 "variable")))
     (it "detects a function from within the function's body"
-      (expect (with-mark-at-line buffer1 33 (pytest-info-current-pos))
+      (expect (with-mark-at-line buffer1 34 (pytest-info-current-pos))
               :to-equal (list filepath1 "test_xfail")))))
 
 

--- a/tests/test-process.el
+++ b/tests/test-process.el
@@ -24,14 +24,19 @@
 (require 'pytest-process)
 
 (describe "pytest commands"
-  (it "constructs the base command without args (pytest--command)"
-    (expect (pytest--command) :to-equal '("python" "-m" "pytest"))
+  (it "constructs the python command (pytest--python)"
+    (expect (pytest--python) :to-match "/python$")
     (let ((pytest-python-executable "/usr/bin/python"))
-      (expect (pytest--command) :to-equal '("/usr/bin/python" "-m" "pytest"))))
+      (expect (pytest--python) :to-equal "/usr/bin/python"))
+    (let ((pytest-python-executable "/usr/local/bin/python"))
+      (expect (pytest--python) :to-equal "/usr/local/bin/python")))
+
+  (it "constructs the base command without args (pytest--command)"
+    (expect (pytest--command) :to-equal (list (pytest--python) "-m" "pytest")))
 
   (it "constructs the command with args (pytest--construct-commands)"
     (expect (pytest--construct-command '("-v" "--color=yes"))
-            :to-equal "python -m pytest -v --color=yes")))
+            :to-match "python -m pytest -v --color=yes")))
 
 (provide 'test-process)
 ;;; test-process.el ends here

--- a/tests/test_example1.py
+++ b/tests/test_example1.py
@@ -78,3 +78,9 @@ def test_nested():
         return func2()
 
     assert func() == 1
+
+
+def test_long_running():
+    import time
+
+    time.sleep(2)


### PR DESCRIPTION
The functions calling `pytest` are currently a hack, and `pytest-raw-mode` is a minor mode intended for `shell-mode`. The issue with that is that that defines a bunch of other keybindings, and it in general is weird to have something that is intended as a major mode be a minor mode.

This uses `start-process-shell-command` instead of `shell-command` with a `&` suffix (the `sh` syntax to run something in the background), and also converts `pytest-raw-mode` to a major mode while keeping color coding.